### PR TITLE
Add a rescue from RGeo::Error::InvalidGeometry to parse_wkt(string)

### DIFF
--- a/lib/active_record/type/spatial.rb
+++ b/lib/active_record/type/spatial.rb
@@ -91,7 +91,7 @@ module ActiveRecord
         else
           RGeo::WKRep::WKTParser.new(spatial_factory, support_ewkt: true, default_srid: @srid).parse(string)
         end
-      rescue RGeo::Error::ParseError
+      rescue RGeo::Error::ParseError, RGeo::Error::InvalidGeometry
         nil
       end
     end


### PR DESCRIPTION
Hitting an issue like https://github.com/rgeo/rgeo-geojson/issues/33 where we are getting "LinearRing failed ring test (RGeo::Error::InvalidGeometry)" for a valid polygon.  Added rescue from RGeo::Error::InvalidGeometry. In previous version of the adapter, rescue was from all exceptions.