### PR TITLE
Ruby 2.7 Deprecation Warnings

### DIFF
--- a/lib/active_record/connection_adapters/mysql2rgeo/column_methods.rb
+++ b/lib/active_record/connection_adapters/mysql2rgeo/column_methods.rb
@@ -4,47 +4,47 @@ module ActiveRecord
   module ConnectionAdapters
     module Mysql2Rgeo
       module ColumnMethods
-        def spatial(name, options = {})
+        def spatial(name, **options)
           raise "You must set a type. For example: 't.spatial type: :st_point'" unless options[:type]
 
-          column(name, options[:type], options)
+          column(name, options[:type], **options)
         end
 
-        def geometry(name, options = {})
-          column(name, :geometry, options)
+        def geometry(name, **options)
+          column(name, :geometry, **options)
         end
 
-        def geometry_collection(name, options = {})
-          column(name, :geometrycollection, options)
+        def geometry_collection(name, **options)
+          column(name, :geometrycollection, **options)
         end
         alias geometrycollection geometry_collection
 
-        def line_string(name, options = {})
-          column(name, :linestring, options)
+        def line_string(name, **options)
+          column(name, :linestring, **options)
         end
         alias linestring line_string
 
-        def multi_line_string(name, options = {})
-          column(name, :multilinestring, options)
+        def multi_line_string(name, **options)
+          column(name, :multilinestring, **options)
         end
         alias multilinestring multi_line_string
 
-        def multi_point(name, options = {})
-          column(name, :multipoint, options)
+        def multi_point(name, **options)
+          column(name, :multipoint, **options)
         end
         alias multipoint multi_point
 
-        def multi_polygon(name, options = {})
-          column(name, :multipolygon, options)
+        def multi_polygon(name, **options)
+          column(name, :multipolygon, **options)
         end
         alias multipolygon multi_polygon
 
-        def point(name, options = {})
-          column(name, :point, options)
+        def point(name, **options)
+          column(name, :point, **options)
         end
 
-        def polygon(name, options = {})
-          column(name, :polygon, options)
+        def polygon(name, **options)
+          column(name, :polygon, **options)
         end
       end
     end

--- a/lib/active_record/connection_adapters/mysql2rgeo/spatial_table_definition.rb
+++ b/lib/active_record/connection_adapters/mysql2rgeo/spatial_table_definition.rb
@@ -15,9 +15,9 @@ module ActiveRecord  # :nodoc:
             geo_type = ColumnDefinitionUtils.geo_type(options[:type] || type || info[:type])
 
             options[:spatial_type] = geo_type
-            column = super(name, geo_type.downcase.to_sym, options)
+            column = super(name, geo_type.downcase.to_sym, **options)
           else
-            column = super(name, type, options)
+            column = super(name, type, **options)
           end
 
           column


### PR DESCRIPTION
Ruby 2.7 issues the following warning:

> warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call

The behaviour change is due to plans for Ruby 3 to remove support for automatic treatment of hashes as keyword arguments. For example, this code was previously fine but will result in an error in Ruby 3:

```ruby
def double(x:)
  x * 2
end

options = { x: 5 }
double(options)
```

In Ruby 3, an explicit double splat will be required (`double(**options)`).

---

No worries if you're not supporting Ruby 2.7 yet, but I thought this might be useful for others who are running it, and for eventual Ruby 3.0 compatibility.

Have a nice day! :blush: 