### PR TITLE
Fix bug in ActiveRecord::ConnectionAdapters::Mysql2Rgeo::SchemaCreation#add_column_options!

### DIFF
--- a/lib/active_record/connection_adapters/mysql2rgeo/schema_creation.rb
+++ b/lib/active_record/connection_adapters/mysql2rgeo/schema_creation.rb
@@ -7,34 +7,11 @@ module ActiveRecord
         private
 
           def add_column_options!(sql, options)
-            # By default, TIMESTAMP columns are NOT NULL, cannot contain NULL values,
-            # and assigning NULL assigns the current timestamp. To permit a TIMESTAMP
-            # column to contain NULL, explicitly declare it with the NULL attribute.
-            # See https://dev.mysql.com/doc/refman/en/timestamp-initialization.html
-            if /\Atimestamp\b/.match?(options[:column].sql_type) && !options[:primary_key]
-              sql << " NULL" unless options[:null] == false || options_include_default?(options)
-            end
-
             if options[:srid]
               sql << " /*!80003 SRID #{options[:srid]} */"
             end
 
-            if charset = options[:charset]
-              sql << " CHARACTER SET #{charset}"
-            end
-
-            if collation = options[:collation]
-              sql << " COLLATE #{collation}"
-            end
-
-            if as = options[:as]
-              sql << " AS (#{as})"
-              if options[:stored]
-                sql << (mariadb? ? " PERSISTENT" : " STORED")
-              end
-            end
-
-            add_sql_comment!(super, options[:comment])
+            super
           end
       end
     end


### PR DESCRIPTION
Version 6.0.3 of this gem introduced a problem for a `db/schema.rb` that uses the `as:` option to provide additional information to the MySQL schema creation adapter to construct the database schema properly. For example:

```
t.virtual "my_col_virtual", type: :boolean, as: "json_unquote(json_extract(`generated_notifications`,'$.my_col'))"
```

The resulting SQL statement produced for this column contained a duplicate `AS json_unquote(json_extract(generated_notifications,'$.my_col'))`, which failed when Rails tries to create a database schema from `db/schema.rb`.

This pull request changes the overridden `ActiveRecord::ConnectionAdapters::Mysql2Rgeo::SchemaCreation#add_column_options!` method to only add logic for the `options[:srid]` option, and to remove duplicate logic that is already present in ActiveRecord.

We had been using version 6.0 of this gem, so we hadn't seen this issue until we upgraded our app's gems including upgrading to Rails 7.