### PR TITLE
Remove duplication from schema creation

### DIFF
--- a/activerecord-mysql2rgeo-adapter.gemspec
+++ b/activerecord-mysql2rgeo-adapter.gemspec
@@ -23,9 +23,10 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activerecord", "~> 6.1"
   spec.add_dependency "rgeo-activerecord", "~> 7.0.0"
+  spec.add_dependency "rgeo", "~> 2.0"
 
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "minitest", "~> 5.4"
-  spec.add_development_dependency "mocha", "~> 1.1"
+  spec.add_development_dependency "mocha", "~> 2.1"
   spec.add_development_dependency "appraisal", "~> 2.0"
 end

--- a/lib/active_record/connection_adapters/mysql2rgeo/schema_creation.rb
+++ b/lib/active_record/connection_adapters/mysql2rgeo/schema_creation.rb
@@ -7,34 +7,11 @@ module ActiveRecord
         private
 
           def add_column_options!(sql, options)
-            # By default, TIMESTAMP columns are NOT NULL, cannot contain NULL values,
-            # and assigning NULL assigns the current timestamp. To permit a TIMESTAMP
-            # column to contain NULL, explicitly declare it with the NULL attribute.
-            # See https://dev.mysql.com/doc/refman/en/timestamp-initialization.html
-            if /\Atimestamp\b/.match?(options[:column].sql_type) && !options[:primary_key]
-              sql << " NULL" unless options[:null] == false || options_include_default?(options)
-            end
-
             if options[:srid]
               sql << " /*!80003 SRID #{options[:srid]} */"
             end
 
-            if charset = options[:charset]
-              sql << " CHARACTER SET #{charset}"
-            end
-
-            if collation = options[:collation]
-              sql << " COLLATE #{collation}"
-            end
-
-            if as = options[:as]
-              sql << " AS (#{as})"
-              if options[:stored]
-                sql << (mariadb? ? " PERSISTENT" : " STORED")
-              end
-            end
-
-            add_sql_comment!(super, options[:comment])
+            super
           end
       end
     end

--- a/lib/active_record/type/spatial.rb
+++ b/lib/active_record/type/spatial.rb
@@ -40,12 +40,14 @@ module ActiveRecord
       end
 
       def spatial_factory
-        @spatial_factory ||=
+        @spatial_factories ||= {}
+
+        @spatial_factories[@srid] ||=
           RGeo::ActiveRecord::SpatialFactoryStore.instance.factory(
             geo_type: @geo_type,
             sql_type: @sql_type,
             srid: @srid
-          )
+        )
       end
 
       def klass

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -46,7 +46,7 @@ class BasicTest < ActiveSupport::TestCase
     obj2 = SpatialModel.find(id)
     assert_equal factory.point(1.0, 2.0), obj2.latlon
     assert_equal 3857, obj2.latlon.srid
-    # assert_equal true, RGeo::Geos.is_geos?(obj2.latlon)
+    assert_equal true, RGeo::Geos.geos?(obj2.latlon)
   end
 
   def test_save_and_load_geographic_point
@@ -58,7 +58,7 @@ class BasicTest < ActiveSupport::TestCase
     obj2 = SpatialModel.find(id)
     # assert_equal geographic_factory.point(1.0, 2.0), obj2.latlon_geo
     assert_equal 4326, obj2.latlon_geo.srid
-    # assert_equal false, RGeo::Geos.is_geos?(obj2.latlon_geo)
+    # assert_equal false, RGeo::Geos.geos?(obj2.latlon_geo)
   end
 
   def test_save_and_load_point_from_wkt
@@ -124,7 +124,7 @@ class BasicTest < ActiveSupport::TestCase
     point = object.latlon
     # assert_equal 47, point.latitude
     object.shape = point
-    assert_equal true, RGeo::Geos.is_geos?(object.shape)
+    assert_equal true, RGeo::Geos.geos?(object.shape)
 
     spatial_factory_store.clear
   end

--- a/test/ddl_test.rb
+++ b/test/ddl_test.rb
@@ -198,7 +198,7 @@ class DDLTest < ActiveSupport::TestCase
 
   def test_create_geometry_using_shortcut_with_srid
     klass.connection.create_table(:spatial_models, force: true) do |t|
-      t.geometry "latlon", srid: 4326
+      t.geometry "latlon100", srid: 4326
     end
     klass.reset_column_information
     col = klass.columns.last


### PR DESCRIPTION
Targeting 6.x
Similar to https://github.com/stadia/activerecord-mysql2rgeo-adapter/pull/26, this adds extra `COLLATE ` if present in SQL statement, which causes problems with MySQL 8.
Also attempt to fix a few broken specs.