### PR TITLE
Rails 7.2 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       BUNDLE_GEMFILE: ${{matrix.gemfile}}
     strategy:
       matrix:
-        ruby: ['3.0', '2.7']
+        ruby: ['3.1', '2.7']
         gemfile:
           - gemfiles/ar72.gemfile
 #        mysql: ['5.7', '8.0']

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         ruby: ['3.0', '2.7']
         gemfile:
-          - gemfiles/ar70.gemfile
+          - gemfiles/ar72.gemfile
 #        mysql: ['5.7', '8.0']
         mysql: ['5.7']
     steps:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@
 Bundler/OrderedGems:
   Exclude:
     - 'Gemfile'
-    - 'gemfiles/ar70.gemfile'
+    - 'gemfiles/ar71.gemfile'
 
 # Offense count: 2
 # Cop supports --auto-correct.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@
 Bundler/OrderedGems:
   Exclude:
     - 'Gemfile'
-    - 'gemfiles/ar71.gemfile'
+    - 'gemfiles/ar72.gemfile'
 
 # Offense count: 2
 # Cop supports --auto-correct.

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - jruby-9.2.6.0
   - 3.0
 gemfile:
-  - gemfiles/ar70.gemfile
+  - gemfiles/ar72.gemfile
 matrix:
   allow_failures:
     - rvm: jruby-9.2.6.0

--- a/Appraisals
+++ b/Appraisals
@@ -1,3 +1,3 @@
-appraise "ar70" do
-  gem "activerecord", "~> 7.0.0"
+appraise "ar72" do
+  gem "activerecord", "~> 7.2.0"
 end

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,8 @@ Run tests against the test gemfiles:
 run `rake appraisal` or run the tests manually:
 
 ```
-BUNDLE_GEMFILE=./gemfiles/ar70.gemfile bundle
-BUNDLE_GEMFILE=./gemfiles/ar70.gemfile rake
+BUNDLE_GEMFILE=./gemfiles/ar72.gemfile bundle
+BUNDLE_GEMFILE=./gemfiles/ar72.gemfile rake
 ```
 
 Make your changes and submit a pull request.

--- a/activerecord-mysql2rgeo-adapter.gemspec
+++ b/activerecord-mysql2rgeo-adapter.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.7.0"
 
-  spec.add_dependency "activerecord", "~> 7.0.0"
+  spec.add_dependency "activerecord", "~> 7.2.0"
   spec.add_dependency "rgeo-activerecord", "~> 7.0.0"
 
   spec.add_development_dependency "rake", "~> 12.0"

--- a/gemfiles/ar72.gemfile
+++ b/gemfiles/ar72.gemfile
@@ -6,6 +6,6 @@ gem "mysql2", "~> 0.5.2", platform: :ruby
 gem "jdbc-mysql", platform: :jruby
 gem "activerecord-jdbc-adapter", "~> 5.0", platform: :jruby
 gem "ffi-geos", platform: :jruby
-gem "activerecord", "~> 7.0.0"
+gem "activerecord", "~> 7.2.0"
 
 gemspec path: "../"

--- a/lib/active_record/connection_adapters/mysql2rgeo/schema_statements.rb
+++ b/lib/active_record/connection_adapters/mysql2rgeo/schema_statements.rb
@@ -39,7 +39,7 @@ module ActiveRecord
         end
 
         # override
-        def new_column_from_field(table_name, field)
+        def new_column_from_field(table_name, field, _definitions)
           type_metadata = fetch_type_metadata(field[:Type], field[:Extra])
           default, default_function = field[:Default], nil
 

--- a/lib/active_record/connection_adapters/mysql2rgeo/spatial_table_definition.rb
+++ b/lib/active_record/connection_adapters/mysql2rgeo/spatial_table_definition.rb
@@ -22,6 +22,10 @@ module ActiveRecord # :nodoc:
 
           column
         end
+
+        def valid_column_definition_options
+          super + %i[geographic has_m spatial_type srid]
+        end
       end
 
       module ColumnDefinitionUtils

--- a/lib/active_record/connection_adapters/mysql2rgeo/version.rb
+++ b/lib/active_record/connection_adapters/mysql2rgeo/version.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module Mysql2Rgeo
-      VERSION = "7.0.0"
+      VERSION = "7.2.0"
     end
   end
 end

--- a/lib/active_record/connection_adapters/mysql2rgeo_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql2rgeo_adapter.rb
@@ -66,7 +66,7 @@ module ActiveRecord
       # http://postgis.17.x6.nabble.com/Default-SRID-td5001115.html
       DEFAULT_SRID = 0
 
-      def initialize(connection, logger, connection_options, config)
+      def initialize(...) # connection, logger, connection_options, config
         super
 
         @visitor = Arel::Visitors::Mysql2Rgeo.new(self)
@@ -135,6 +135,10 @@ module ActiveRecord
         else
           super
         end
+      end
+
+      def with_connection
+        yield self
       end
 
       private

--- a/lib/active_record/connection_adapters/mysql2rgeo_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql2rgeo_adapter.rb
@@ -66,7 +66,7 @@ module ActiveRecord
       # http://postgis.17.x6.nabble.com/Default-SRID-td5001115.html
       DEFAULT_SRID = 0
 
-      def initialize(...) # connection, logger, connection_options, config
+      def initialize(...)
         super
 
         @visitor = Arel::Visitors::Mysql2Rgeo.new(self)

--- a/lib/activerecord-mysql2rgeo-adapter.rb
+++ b/lib/activerecord-mysql2rgeo-adapter.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
 require "active_record/connection_adapters/mysql2rgeo_adapter"
+
+ActiveRecord::ConnectionAdapters.register('mysql2rgeo', 'ActiveRecord::ConnectionAdapters::Mysql2RgeoAdapter', 'active_record/connection_adapters/mysql2rgeo_adapter')

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -134,7 +134,7 @@ class BasicTest < ActiveSupport::TestCase
     obj = SpatialModel.new
     assert_match(/"latlon":null/, obj.to_json)
     obj.latlon = factory.point(1.0, 2.0)
-    assert_match(/"latlon":"POINT\s\(1\.0\s2\.0\)"/, obj.to_json)
+    assert_match(/"latlon":"POINT\s\(1(\.0)?\s2(\.0)?\)"/, obj.to_json)
   end
 
   def test_custom_column


### PR DESCRIPTION
Changes necessary to build the gem and get passing tests with Rails 7.2

**Note**: The CI build fails with Ruby 2.7. Would the maintainers of https://github.com/stadia/activerecord-mysql2rgeo-adapter be open to the idea of dropping support for Ruby 2.x?