### PR TITLE
Update mocha dependency version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         ruby: ['3.0', '2.7']
         gemfile:
-          - gemfiles/ar70.gemfile
+          - gemfiles/ar71.gemfile
         mysql: ['5.7', '8.0']
     steps:
       - name: Set Up Actions

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,8 +22,7 @@ jobs:
         ruby: ['3.0', '2.7']
         gemfile:
           - gemfiles/ar70.gemfile
-#        mysql: ['5.7', '8.0']
-        mysql: ['5.7']
+        mysql: ['5.7', '8.0']
     steps:
       - name: Set Up Actions
         uses: actions/checkout@v2

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@
 Bundler/OrderedGems:
   Exclude:
     - 'Gemfile'
-    - 'gemfiles/ar70.gemfile'
+    - 'gemfiles/ar71.gemfile'
 
 # Offense count: 2
 # Cop supports --auto-correct.

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - jruby-9.2.6.0
   - 3.0
 gemfile:
-  - gemfiles/ar70.gemfile
+  - gemfiles/ar71.gemfile
 matrix:
   allow_failures:
     - rvm: jruby-9.2.6.0

--- a/Appraisals
+++ b/Appraisals
@@ -1,3 +1,3 @@
-appraise "ar70" do
-  gem "activerecord", "~> 7.0.0"
+appraise "ar71" do
+  gem "activerecord", "~> 7.1.0"
 end

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,8 @@ Run tests against the test gemfiles:
 run `rake appraisal` or run the tests manually:
 
 ```
-BUNDLE_GEMFILE=./gemfiles/ar70.gemfile bundle
-BUNDLE_GEMFILE=./gemfiles/ar70.gemfile rake
+BUNDLE_GEMFILE=./gemfiles/ar71.gemfile bundle
+BUNDLE_GEMFILE=./gemfiles/ar71.gemfile rake
 ```
 
 Make your changes and submit a pull request.

--- a/activerecord-mysql2rgeo-adapter.gemspec
+++ b/activerecord-mysql2rgeo-adapter.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.7.0"
 
-  spec.add_dependency "activerecord", "~> 7.0.0"
+  spec.add_dependency "activerecord", "~> 7.1.0"
   spec.add_dependency "rgeo-activerecord", "~> 7.0.0"
   spec.add_dependency "rgeo", "~> 2.0"
 

--- a/activerecord-mysql2rgeo-adapter.gemspec
+++ b/activerecord-mysql2rgeo-adapter.gemspec
@@ -23,9 +23,10 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activerecord", "~> 7.0.0"
   spec.add_dependency "rgeo-activerecord", "~> 7.0.0"
+  spec.add_dependency "rgeo", "~> 2.0"
 
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "minitest", "~> 5.4"
-  spec.add_development_dependency "mocha", "~> 2.0"
+  spec.add_development_dependency "mocha", "~> 2.1"
   spec.add_development_dependency "appraisal", "~> 2.0"
 end

--- a/activerecord-mysql2rgeo-adapter.gemspec
+++ b/activerecord-mysql2rgeo-adapter.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "minitest", "~> 5.4"
-  spec.add_development_dependency "mocha", "~> 1.1"
+  spec.add_development_dependency "mocha", "~> 2.0"
   spec.add_development_dependency "appraisal", "~> 2.0"
 end

--- a/gemfiles/ar71.gemfile
+++ b/gemfiles/ar71.gemfile
@@ -6,6 +6,6 @@ gem "mysql2", "~> 0.5.2", platform: :ruby
 gem "jdbc-mysql", platform: :jruby
 gem "activerecord-jdbc-adapter", "~> 5.0", platform: :jruby
 gem "ffi-geos", platform: :jruby
-gem "activerecord", "~> 7.0.0"
+gem "activerecord", "~> 7.1.0"
 
 gemspec path: "../"

--- a/lib/active_record/connection_adapters/mysql2rgeo/schema_statements.rb
+++ b/lib/active_record/connection_adapters/mysql2rgeo/schema_statements.rb
@@ -39,7 +39,7 @@ module ActiveRecord
         end
 
         # override
-        def new_column_from_field(table_name, field)
+        def new_column_from_field(table_name, field, _definitions)
           type_metadata = fetch_type_metadata(field[:Type], field[:Extra])
           default, default_function = field[:Default], nil
 

--- a/lib/active_record/connection_adapters/mysql2rgeo/version.rb
+++ b/lib/active_record/connection_adapters/mysql2rgeo/version.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module Mysql2Rgeo
-      VERSION = "7.0.1"
+      VERSION = "7.1.0"
     end
   end
 end

--- a/lib/active_record/connection_adapters/mysql2rgeo/version.rb
+++ b/lib/active_record/connection_adapters/mysql2rgeo/version.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module Mysql2Rgeo
-      VERSION = "7.0.0"
+      VERSION = "7.0.1"
     end
   end
 end

--- a/lib/active_record/type/spatial.rb
+++ b/lib/active_record/type/spatial.rb
@@ -47,7 +47,7 @@ module ActiveRecord
             geo_type: @geo_type,
             sql_type: @sql_type,
             srid: @srid
-          )
+        )
       end
 
       def klass

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -46,7 +46,7 @@ class BasicTest < ActiveSupport::TestCase
     obj2 = SpatialModel.find(id)
     assert_equal factory.point(1.0, 2.0), obj2.latlon
     assert_equal 3857, obj2.latlon.srid
-    # assert_equal true, RGeo::Geos.is_geos?(obj2.latlon)
+    assert_equal true, RGeo::Geos.geos?(obj2.latlon)
   end
 
   def test_save_and_load_geographic_point
@@ -58,7 +58,7 @@ class BasicTest < ActiveSupport::TestCase
     obj2 = SpatialModel.find(id)
     # assert_equal geographic_factory.point(1.0, 2.0), obj2.latlon_geo
     assert_equal 4326, obj2.latlon_geo.srid
-    # assert_equal false, RGeo::Geos.is_geos?(obj2.latlon_geo)
+    # assert_equal false, RGeo::Geos.geos?(obj2.latlon_geo)
   end
 
   def test_save_and_load_point_from_wkt

--- a/test/ddl_test.rb
+++ b/test/ddl_test.rb
@@ -198,7 +198,7 @@ class DDLTest < ActiveSupport::TestCase
 
   def test_create_geometry_using_shortcut_with_srid
     klass.connection.create_table(:spatial_models, force: true) do |t|
-      t.geometry "latlon", srid: 4326
+      t.geometry "latlon100", srid: 4326
     end
     klass.reset_column_information
     col = klass.columns.last


### PR DESCRIPTION
The mocha dependency was updated from version 1.1 to 2.0 to leverage the latest features and improvements of the mocha library in the development process.